### PR TITLE
Separate out factorization triangular solves into two steps, roughly halving flops

### DIFF
--- a/tests/kkt_test_1/test.cpp
+++ b/tests/kkt_test_1/test.cpp
@@ -73,8 +73,15 @@ TEST(SLACG, Test) {
     y[i] = -b[i];
   }
 
+  double *x_x = &x[0];
+  double *x_y = &x[x_dim];
+  double *x_z = &x[x_dim + y_dim];
+  double *y_x = &y[0];
+  double *y_y = &y[x_dim];
+  double *y_z = &y[x_dim + y_dim];
+
   slacg::test::add_Kx_to_y(H_data.data(), C_data.data(), G_data.data(),
-                           s.data(), r2, r2, r3, x.data(), y.data());
+                           s.data(), r2, r2, r3, x_x, x_y, x_z, y_x, y_y, y_z);
 
   for (std::size_t i = 0; i < y.size(); ++i) {
     EXPECT_NEAR(y[i], 0.0, 1e-11);


### PR DESCRIPTION
Rather than merging the `D[:k-1,:k-1] \ (L[:k-1,:k-1] \ A[:k-1, k])` solves into a single calculation, which requires doing $L_{ij} = \frac{1}{D_{jj}} (A_{ij} - \sum_{k=0}^{j-1} L_{ik} L_{jk} D_{kk})$, we can do $L_{ij}' = A_{ij} - \sum_{k=0}^{j-1} L_{ik}' L_{jk}$ first and then calculate $L_{ij} = \frac{L_{ij}'}{D_{jj}}$ in a second step. This reduces the inner loop in the LDLT factorization into a series of fused multiply add instructions, instead of a multiply instruction followed by a fused multiply add, thereby approximately halving the number of floating point operations.